### PR TITLE
Integrating Quarkus Zalando problem

### DIFF
--- a/generators/server/templates/quarkus/build.gradle.ejs
+++ b/generators/server/templates/quarkus/build.gradle.ejs
@@ -242,6 +242,7 @@ dependencies {
     implementation "io.micrometer:micrometer-registry-prometheus"
     implementation "org.mapstruct:mapstruct:${mapstruct_version}"
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
+    implementation "solutions.cloudstark.quarkus:quarkus-zalando-problem:${quarkus_zalando_problem}"
 
     liquibaseRuntime "org.liquibase:liquibase-core"
     liquibaseRuntime "org.liquibase.ext:liquibase-hibernate5:${liquibase_hibernate5_version}"

--- a/generators/server/templates/quarkus/gradle.properties.ejs
+++ b/generators/server/templates/quarkus/gradle.properties.ejs
@@ -33,6 +33,7 @@ yarn_version=<%= YARN_VERSION %>
 hibernate_version=5.4.12.Final
 mapstruct_version=1.3.1.Final
 archunit_junit5_version=0.13.1
+quarkus_zalando_problem=1.0.0
 <%_ if (searchEngine === 'elasticsearch') { _%>
 log4j2_mock_version=0.0.2
 <%_ } _%>

--- a/generators/server/templates/quarkus/pom.xml.ejs
+++ b/generators/server/templates/quarkus/pom.xml.ejs
@@ -44,6 +44,7 @@
         <quarkus.platform.version><%= quarkusVersion %></quarkus.platform.version>
         <mapstruct.version>1.3.1.Final</mapstruct.version>
         <archunit-junit5.version>0.12.0</archunit-junit5.version>
+        <quarkus-zalando-problem.version>1.0.0</quarkus-zalando-problem.version>
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -183,6 +184,11 @@
             <version>${jacoco-maven-plugin.version}</version>
             <classifier>runtime</classifier>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>solutions.cloudstark.quarkus</groupId>
+            <artifactId>quarkus-zalando-problem</artifactId>
+            <version>${quarkus-zalando-problem.version}</version>
         </dependency>
         <!-- jhipster-needle-maven-add-dependency -->
     </dependencies>
@@ -682,4 +688,16 @@
         </profile>
         <!-- jhipster-needle-maven-add-profile -->
     </profiles>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-cloudstark-maven</id>
+            <name>bintray</name>
+            <url>https://dl.bintray.com/cloudstark/maven</url>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION
The spring generator relies on Zalando problem library to produce machine friendly HTTP response.
This PR aims to align Quarkus to this API contract.

The PR relies on https://github.com/cloudstark/quarkus-zalando-problem-extension