### PR TITLE
Add a MailServiceIT.java for testing purpose

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -258,6 +258,10 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
+                    file: 'package/service/MailServiceIT.java',
+                    renameTo: generator => `${generator.javaDir}/service/MailServiceIT.java`
+                },
+                {
                     file: 'package/service/mapper/UserMapperTest.java',
                     renameTo: generator => `${generator.javaDir}/service/mapper/UserMapperTest.java`
                 },

--- a/generators/server/templates/quarkus/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/quarkus/src/test/java/package/service/MailServiceIT.java.ejs
@@ -1,0 +1,103 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.service;
+
+import <%= packageName %>.domain.User;
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.MockMailbox;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link MailService}.
+ */
+@QuarkusTest
+public class MailServiceIT {
+    @Inject
+    MockMailbox mailbox;
+
+    @Inject
+    MailService mailService;
+
+    private static final String[] languages = {
+        // jhipster-needle-i18n-language-constant - JHipster will add/remove languages in this array
+        //  TODO this array should be used along side Localized templates to ensure languages are correctly handle
+        // see https://github.com/quarkusio/quarkus/issues/7665
+        // https://quarkus.io/guides/qute-reference#localization
+    };
+
+    @BeforeEach
+    void init() {
+        mailbox.clear();
+    }
+
+    User user() {
+        User user = new User();
+        user.login = "john";
+        user.email = "john.doe@example.com";
+        user.langKey = "en";
+
+        return user;
+    }
+
+    @Test
+    void should_containsActivationInfosWhenCallSendActivationEmail() {
+        User user = user();
+
+        mailService.sendActivationEmail(user);
+
+        List<Mail> sent = mailbox.getMessagesSentTo(user.email);
+        assertThat(sent).hasSize(1);
+        Mail actual = sent.get(0);
+        assertThat(actual.getHtml()).contains("Your JHipster account has been created, please click on the URL below to activate it:");
+        assertThat(actual.getSubject()).isEqualTo("jhipsterSampleApplication account activation is required");
+    }
+
+    @Test
+    void should_containsActivationInfosWhenCallSendCreationEmail() {
+        User user = user();
+
+        mailService.sendCreationEmail(user);
+
+        List<Mail> sent = mailbox.getMessagesSentTo(user.email);
+        assertThat(sent).hasSize(1);
+        Mail actual = sent.get(0);
+        assertThat(actual.getHtml()).contains("Your JHipster account has been created, please click on the URL below to access it:");
+        assertThat(actual.getSubject()).isEqualTo("jhipsterSampleApplication account activation is required");
+    }
+
+    @Test
+    void should_containsResetInfosWhenCallSendPasswordResetMail() {
+        User user = user();
+
+        mailService.sendPasswordResetMail(user);
+
+        List<Mail> sent = mailbox.getMessagesSentTo(user.email);
+        assertThat(sent).hasSize(1);
+        Mail actual = sent.get(0);
+        assertThat(actual.getHtml()).contains("For your JHipster account a password reset was requested, please click on the URL below to reset it:");
+        assertThat(actual.getSubject()).isEqualTo("jhipsterSampleApplication password reset");
+    }
+}

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -48,6 +48,7 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/util/ResponseUtil.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/domain/AuthorityTest.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/domain/UserTest.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/service/MailServiceIT.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/service/mapper/UserMapperTest.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/AccountResourceTest.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/UserJWTControllerTest.java`,


### PR DESCRIPTION
fix https://github.com/jhipster/generator-jhipster-quarkus/issues/113

I'm not 100% satisfied because I would like to handle localization feature in mail and ensure our mail will be rendered in the right language. The problem is that it's seems to need more work than I expected and I don't think this is worth considered we target to finish the 1.0.0 first.

This PR at least add a test classes for MailService and improve the coverage and fix the error message quote in the issue.

Next plan should be to handle i18n properly in mail templates.

sources:
https://github.com/quarkusio/quarkus/issues/7665
https://quarkus.io/guides/qute-reference#localization