### PR TITLE
Fix metrics page

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -25,6 +25,10 @@ const filesAngular = {
         {
             path: ANGULAR_DIR,
             templates: [{ file: 'admin/health/health.component.html', method: 'processHtml' }, 'admin/health/health.service.ts']
+        },
+        {
+            path: ANGULAR_DIR,
+            templates: [{ file: 'admin/metrics/metrics.component.html', method: 'processHtml' }, 'admin/metrics/metrics.component.ts']
         }
     ],
     clientTestFw: [

--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -28,13 +28,17 @@ const filesAngular = {
         },
         {
             path: ANGULAR_DIR,
-            templates: [{ file: 'admin/metrics/metrics.component.html', method: 'processHtml' }, 'admin/metrics/metrics.component.ts']
+            templates: [
+                { file: 'admin/metrics/metrics.component.html', method: 'processHtml' },
+                'admin/metrics/metrics.component.ts',
+                'admin/metrics/metrics.service.ts'
+            ]
         }
     ],
     clientTestFw: [
         {
             path: CLIENT_TEST_SRC_DIR,
-            templates: ['spec/app/admin/health/health.component.spec.ts']
+            templates: ['spec/app/admin/metrics/metrics.service.spec.ts', 'spec/app/admin/health/health.component.spec.ts']
         }
     ]
 };

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -24,7 +24,10 @@ const filesReact = {
     adminModule: [
         {
             path: REACT_DIR,
-            templates: [{ file: 'modules/administration/health/health.tsx', method: 'processJsx' }]
+            templates: [
+                { file: 'modules/administration/health/health.tsx', method: 'processJsx' },
+                { file: 'modules/administration/metrics/metrics.tsx', method: 'processJsx' }
+            ]
         }
     ]
 };

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -1,0 +1,78 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<div>
+    <h2>
+        <span id="metrics-page-heading" jhiTranslate="metrics.title">Application Metrics</span>
+
+        <button class="btn btn-primary float-right" (click)="refresh()">
+            <fa-icon icon="sync"></fa-icon> <span jhiTranslate="metrics.refresh.button">Refresh</span>
+        </button>
+    </h2>
+
+    <h3 jhiTranslate="metrics.jvm.title">JVM Metrics</h3>
+
+    <div class="row" *ngIf="metrics && !updatingMetrics">
+        <jhi-jvm-memory
+            class="col-md-4"
+            [updating]="updatingMetrics"
+            [jvmMemoryMetrics]="metrics.jvm">
+        </jhi-jvm-memory>
+
+        <jhi-metrics-system
+            class="col-md-4"
+            [updating]="updatingMetrics"
+            [systemMetrics]="metrics.processMetrics">
+        </jhi-metrics-system>
+    </div>
+
+    <div *ngIf="metrics && metricsKeyExists('garbageCollector')">
+        <h3 jhiTranslate="metrics.jvm.gc.title">Garbage collector statistics</h3>
+
+        <jhi-metrics-garbagecollector
+            [updating]="updatingMetrics"
+            [garbageCollectorMetrics]="metrics.garbageCollector">
+        </jhi-metrics-garbagecollector>
+    </div>
+
+    <div class="well well-lg" *ngIf="updatingMetrics" jhiTranslate="metrics.updating">Updating...</div>
+
+    <jhi-metrics-request
+        *ngIf="metrics && metricsKeyExists('http.server.requests')"
+        [updating]="updatingMetrics"
+        [requestMetrics]="metrics['http.server.requests']">
+    </jhi-metrics-request>
+
+    <jhi-metrics-endpoints-requests
+        *ngIf="metrics && metricsKeyExists('services')"
+        [updating]="updatingMetrics"
+        [endpointsRequestsMetrics]="metrics.services">
+    </jhi-metrics-endpoints-requests>
+
+    <jhi-metrics-cache
+        *ngIf="metrics && metricsKeyExists('cache')"
+        [updating]="updatingMetrics"
+        [cacheMetrics]="metrics.cache">
+    </jhi-metrics-cache>
+
+    <jhi-metrics-datasource
+        *ngIf="metrics && metricsKeyExistsAndObjectNotEmpty('databases')"
+        [updating]="updatingMetrics"
+        [datasourceMetrics]="metrics.databases">
+    </jhi-metrics-datasource>
+</div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -29,13 +29,13 @@
 
     <div class="row" *ngIf="metrics && !updatingMetrics">
         <jhi-jvm-memory
-            class="col-md-4"
+            class="col-md-6"
             [updating]="updatingMetrics"
             [jvmMemoryMetrics]="metrics.jvm">
         </jhi-jvm-memory>
 
         <jhi-metrics-system
-            class="col-md-4"
+            class="col-md-6"
             [updating]="updatingMetrics"
             [systemMetrics]="metrics.processMetrics">
         </jhi-metrics-system>
@@ -63,16 +63,4 @@
         [updating]="updatingMetrics"
         [endpointsRequestsMetrics]="metrics.services">
     </jhi-metrics-endpoints-requests>
-
-    <jhi-metrics-cache
-        *ngIf="metrics && metricsKeyExists('cache')"
-        [updating]="updatingMetrics"
-        [cacheMetrics]="metrics.cache">
-    </jhi-metrics-cache>
-
-    <jhi-metrics-datasource
-        *ngIf="metrics && metricsKeyExistsAndObjectNotEmpty('databases')"
-        [updating]="updatingMetrics"
-        [datasourceMetrics]="metrics.databases">
-    </jhi-metrics-datasource>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
@@ -1,0 +1,56 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+
+import { MetricsService, Metrics, MetricsKey } from './metrics.service';
+
+@Component({
+    selector: '<%= jhiPrefixDashed %>-metrics',
+    templateUrl: './metrics.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MetricsComponent implements OnInit {
+    metrics?: Metrics;
+    updatingMetrics = true;
+
+    constructor(private metricsService: MetricsService, private changeDetector: ChangeDetectorRef) {}
+
+    ngOnInit(): void {
+        this.refresh();
+    }
+
+    refresh(): void {
+      this.updatingMetrics = true;
+      this.metricsService
+        .getMetrics()
+        .subscribe((metrics) => {
+          this.metrics = metrics;
+          this.updatingMetrics = false;
+          this.changeDetector.detectChanges();
+        });
+    }
+
+    metricsKeyExists(key: MetricsKey): boolean {
+        return this.metrics && this.metrics[key];
+    }
+
+    metricsKeyExistsAndObjectNotEmpty(key: MetricsKey): boolean {
+        return this.metrics && this.metrics[key] && JSON.stringify(this.metrics[key]) !== '{}';
+    }
+}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.ts.ejs
@@ -1,0 +1,35 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { SERVER_API_URL } from 'app/app.constants';
+
+export type MetricsKey = 'jvm' | 'http.server.requests' | 'services' | 'garbageCollector' | 'processMetrics';
+export type Metrics = { [key in MetricsKey]: any };
+
+@Injectable({ providedIn: 'root' })
+export class MetricsService {
+    constructor(private http: HttpClient) {}
+
+    getMetrics(): Observable<Metrics> {
+        return this.http.get<Metrics>(SERVER_API_URL + 'management/jhimetrics');
+    }
+}

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.service.spec.ts.ejs
@@ -1,0 +1,71 @@
+<%#
+Copyright 2013-2020 the original author or authors from the JHipster project.
+
+    This file is part of the JHipster project, see https://www.jhipster.tech/
+    for more information.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+limitations under the License.
+-%>
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { MetricsService, Metrics } from 'app/admin/metrics/metrics.service';
+import { SERVER_API_URL } from 'app/app.constants';
+
+describe('Service Tests', () => {
+    describe('Logs Service', () => {
+        let service: MetricsService;
+        let httpMock: HttpTestingController;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [HttpClientTestingModule]
+            });
+            service = TestBed.get(MetricsService);
+            httpMock = TestBed.get(HttpTestingController);
+        });
+
+        afterEach(() => {
+            httpMock.verify();
+        });
+
+        describe('Service methods', () => {
+            it('should call correct URL', () => {
+                service.getMetrics().subscribe();
+
+                const req = httpMock.expectOne({ method: 'GET' });
+                const resourceUrl = SERVER_API_URL + 'management/jhimetrics';
+                expect(req.request.url).toEqual(resourceUrl);
+            });
+
+            it('should return Metrics', () => {
+                let expectedResult: Metrics | null = null;
+                const metrics: Metrics = {
+                    jvm: {},
+                    'http.server.requests': {},
+                    services: {},
+                    garbageCollector: {},
+                    processMetrics: {}
+                };
+
+                service.getMetrics().subscribe(received => {
+                    expectedResult = received;
+                });
+
+                const req = httpMock.expectOne({ method: 'GET' });
+                req.flush(metrics);
+                expect(expectedResult).toEqual(metrics);
+            });
+        });
+    });
+});

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -1,0 +1,123 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+import { Button, Col, Row } from 'reactstrap';
+import {
+  GarbageCollectorMetrics,
+  HttpRequestMetrics,
+  JvmMemory,
+  EndpointsRequestsMetrics,
+  SystemMetrics,
+  Translate
+} from 'react-jhipster';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { APP_TIMESTAMP_FORMAT, APP_TWO_DIGITS_AFTER_POINT_NUMBER_FORMAT, APP_WHOLE_NUMBER_FORMAT } from 'app/config/constants';
+import { systemMetrics } from '../administration.reducer';
+import { IRootState } from 'app/shared/reducers';
+
+export interface IMetricsPageProps extends StateProps, DispatchProps {}
+
+export const MetricsPage = (props: IMetricsPageProps) => {
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    props.systemMetrics();
+  }, []);
+
+  const getMetrics = () => {
+    if (!props.isFetching) {
+      props.systemMetrics();
+    }
+  };
+
+  const { metrics, isFetching } = props;
+
+  return (
+    <div>
+      <h2 id="metrics-page-heading">Application Metrics</h2>
+      <p>
+        <Button onClick={getMetrics} color={isFetching ? 'btn btn-danger' : 'btn btn-primary'} disabled={isFetching}>
+          <FontAwesomeIcon icon="sync" />
+          &nbsp;
+          <Translate component="span" contentKey="health.refresh.button">
+            Refresh
+          </Translate>
+        </Button>
+      </p>
+      <hr />
+
+      <Row>
+        <Col sm="12">
+          <h3>JVM Metrics</h3>
+          <Row>
+            <Col md="6">
+              {metrics && metrics.jvm ? <JvmMemory jvmMetrics={metrics.jvm} wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT} /> : ''}
+            </Col>
+            <Col md="6">
+              {metrics && metrics.processMetrics ? (
+                <SystemMetrics
+                  systemMetrics={metrics.processMetrics}
+                  wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT}
+                  timestampFormat={APP_TIMESTAMP_FORMAT}
+                />
+              ) : (
+                ''
+              )}
+            </Col>
+          </Row>
+        </Col>
+      </Row>
+
+      {metrics && metrics.garbageCollector ? (
+        <GarbageCollectorMetrics garbageCollectorMetrics={metrics.garbageCollector} wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT} />
+      ) : (
+        ''
+      )}
+      {metrics && metrics['http.server.requests'] ? (
+        <HttpRequestMetrics
+          requestMetrics={metrics['http.server.requests']}
+          twoDigitAfterPointFormat={APP_TWO_DIGITS_AFTER_POINT_NUMBER_FORMAT}
+          wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT}
+        />
+      ) : (
+        ''
+      )}
+      {metrics && metrics.services ? (
+        <EndpointsRequestsMetrics endpointsRequestsMetrics={metrics.services} wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT} />
+      ) : (
+        ''
+      )}
+
+    </div>
+  );
+};
+
+const mapStateToProps = (storeState: IRootState) => ({
+  metrics: storeState.administration.metrics,
+  isFetching: storeState.administration.loading
+});
+
+const mapDispatchToProps = { systemMetrics };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
+
+export default connect(mapStateToProps, mapDispatchToProps)(MetricsPage);

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -457,6 +457,10 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}web/rest/ManagementInfoResource.java`
                 },
                 {
+                    file: 'package/web/rest/JHipsterMetricsEndpoint.java',
+                    renameTo: generator => `${generator.javaDir}web/rest/JHipsterMetricsEndpoint.java`
+                },
+                {
                     file: 'package/web/util/HeaderUtil.java',
                     renameTo: generator => `${generator.javaDir}web/util/HeaderUtil.java`
                 },

--- a/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
+++ b/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
@@ -120,6 +120,7 @@ public class JHipsterMetricsEndpoint {
 
             resultsGarbageCollector.putIfAbsent(key, gcPauseResults);
         });
+        resultsGarbageCollector.putIfAbsent("jvm.gc.pause", new HashMap<>());
 
         Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("jvm.gc") && !s.contains("jvm.gc.pause")).gauges();
         gauges.forEach(gauge -> resultsGarbageCollector.put(gauge.getId().getName(), gauge.value()));

--- a/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
+++ b/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
@@ -74,12 +74,8 @@ public class JHipsterMetricsEndpoint {
         results.put("jvm", this.jvmMemoryMetrics());
         // HTTP requests stats
         results.put("http.server.requests", this.httpRequestsMetrics());
-        // Cache stats
-        results.put("cache", this.cacheMetrics());
         // Service stats
         results.put("services", this.serviceMetrics());
-        // Database stats
-        results.put("databases", this.databaseMetrics());
         // Garbage collector
         results.put("garbageCollector", this.garbageCollectorMetrics());
         // Process stats
@@ -139,35 +135,6 @@ public class JHipsterMetricsEndpoint {
         return resultsGarbageCollector;
     }
 
-    private Map<String, Map<String, Number>> databaseMetrics() {
-        Map<String, Map<String, Number>> resultsDatabase = new HashMap<>();
-
-        Collection<Timer> timers = Search.in(this.meterRegistry).name(s -> s.contains("hikari")).timers();
-        timers.forEach(timer -> {
-            String key = timer.getId().getName().substring(timer.getId().getName().lastIndexOf('.') + 1);
-
-            resultsDatabase.putIfAbsent(key, new HashMap<>());
-            resultsDatabase.get(key).put("count", timer.count());
-            resultsDatabase.get(key).put("max", timer.max(TimeUnit.MILLISECONDS));
-            resultsDatabase.get(key).put("totalTime", timer.totalTime(TimeUnit.MILLISECONDS));
-            resultsDatabase.get(key).put("mean", timer.mean(TimeUnit.MILLISECONDS));
-
-            ValueAtPercentile[] percentiles = timer.takeSnapshot().percentileValues();
-            for (ValueAtPercentile percentile : percentiles) {
-                resultsDatabase.get(key).put(String.valueOf(percentile.percentile()), percentile.value(TimeUnit.MILLISECONDS));
-            }
-        });
-
-        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("hikari")).gauges();
-        gauges.forEach(gauge -> {
-            String key = gauge.getId().getName().substring(gauge.getId().getName().lastIndexOf('.') + 1);
-            resultsDatabase.putIfAbsent(key, new HashMap<>());
-            resultsDatabase.get(key).put("value", gauge.value());
-        });
-
-        return resultsDatabase;
-    }
-
     private Map<String, Map> serviceMetrics() {
         Collection<String> crudOperation = Arrays.asList("GET", "POST", "PUT", "DELETE");
 
@@ -202,38 +169,6 @@ public class JHipsterMetricsEndpoint {
         });
 
         return resultsHttpPerUri;
-    }
-
-    private Map<String, Map<String, Number>> cacheMetrics() {
-        Map<String, Map<String, Number>> resultsCache = new HashMap<>();
-
-        Collection<FunctionCounter> counters = Search.in(this.meterRegistry).name(s -> s.contains("cache") && !s.contains("hibernate")).functionCounters();
-        counters.forEach(counter -> {
-            String key = counter.getId().getName();
-            String name = counter.getId().getTag("name");
-            if (name != null) {
-                resultsCache.putIfAbsent(name, new HashMap<>());
-                if (counter.getId().getTag("result") != null) {
-                    key += "." + counter.getId().getTag("result");
-                }
-                resultsCache.get(name).put(key, counter.count());
-            } else {
-                logger.warn(MISSING_NAME_TAG_MESSAGE, key);
-            }
-        });
-
-        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("cache")).gauges();
-        gauges.forEach(gauge -> {
-            String key = gauge.getId().getName();
-            String name = gauge.getId().getTag("name");
-            if (name != null) {
-                resultsCache.putIfAbsent(name, new HashMap<>());
-                resultsCache.get(name).put(key, gauge.value());
-            } else {
-                logger.warn(MISSING_NAME_TAG_MESSAGE, key);
-            }
-        });
-        return resultsCache;
     }
 
     private Map<String, Map<String, Number>> jvmMemoryMetrics() {

--- a/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
+++ b/generators/server/templates/quarkus/src/main/java/package/web/rest/JHipsterMetricsEndpoint.java.ejs
@@ -1,0 +1,303 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.search.Search;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>JHipsterMetricsEndpoint class.</p>
+ */
+@Path("/management")
+@Produces(MediaType.APPLICATION_JSON)
+public class JHipsterMetricsEndpoint {
+
+    private final Logger logger = LoggerFactory.getLogger(JHipsterMetricsEndpoint.class);
+
+    /** Constant <code>MISSING_NAME_TAG_MESSAGE="Missing name tag for metric {}"</code> */
+    public static final String MISSING_NAME_TAG_MESSAGE = "Missing name tag for metric {}";
+
+    final MeterRegistry meterRegistry;
+
+    /**
+     * <p>Constructor for JHipsterMetricsEndpoint.</p>
+     *
+     * @param meterRegistry a {@link io.micrometer.core.instrument.MeterRegistry} object.
+     */
+    @Inject
+    public JHipsterMetricsEndpoint(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * GET /management/jhi-metrics
+     * <p>
+     * Give metrics displayed on Metrics page
+     *
+     * @return a Map with a String defining a category of metrics as Key and
+     * another Map containing metrics related to this category as Value
+     */
+    @GET
+    @Path("/jhimetrics")
+    public Map<String, Map> allMetrics() {
+
+        Map<String, Map> results = new HashMap<>();
+        // JVM stats
+        results.put("jvm", this.jvmMemoryMetrics());
+        // HTTP requests stats
+        results.put("http.server.requests", this.httpRequestsMetrics());
+        // Cache stats
+        results.put("cache", this.cacheMetrics());
+        // Service stats
+        results.put("services", this.serviceMetrics());
+        // Database stats
+        results.put("databases", this.databaseMetrics());
+        // Garbage collector
+        results.put("garbageCollector", this.garbageCollectorMetrics());
+        // Process stats
+        results.put("processMetrics", this.processMetrics());
+
+        return results;
+    }
+
+    private Map<String, Number> processMetrics() {
+        Map<String, Number> resultsProcess = new HashMap<>();
+
+        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("cpu") || s.contains("system") || s.contains("process")).gauges();
+        gauges.forEach(gauge -> resultsProcess.put(gauge.getId().getName(), gauge.value()));
+
+        Collection<TimeGauge> timeGauges = Search.in(this.meterRegistry).name(s -> s.contains("process")).timeGauges();
+        timeGauges.forEach(gauge -> resultsProcess.put(gauge.getId().getName(), gauge.value(TimeUnit.MILLISECONDS)));
+
+        return resultsProcess;
+    }
+
+    private Map<String, Object> garbageCollectorMetrics() {
+        Map<String, Object> resultsGarbageCollector = new HashMap<>();
+
+        Collection<Timer> timers = Search.in(this.meterRegistry).name(s -> s.contains("jvm.gc.pause")).timers();
+        timers.forEach(timer -> {
+            String key = timer.getId().getName();
+
+            HashMap<String, Number> gcPauseResults = new HashMap<>();
+            gcPauseResults.put("count", timer.count());
+            gcPauseResults.put("max", timer.max(TimeUnit.MILLISECONDS));
+            gcPauseResults.put("totalTime", timer.totalTime(TimeUnit.MILLISECONDS));
+            gcPauseResults.put("mean", timer.mean(TimeUnit.MILLISECONDS));
+
+            ValueAtPercentile[] percentiles = timer.takeSnapshot().percentileValues();
+            for (ValueAtPercentile percentile : percentiles) {
+                gcPauseResults.put(String.valueOf(percentile.percentile()), percentile.value(TimeUnit.MILLISECONDS));
+            }
+
+            resultsGarbageCollector.putIfAbsent(key, gcPauseResults);
+        });
+
+        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("jvm.gc") && !s.contains("jvm.gc.pause")).gauges();
+        gauges.forEach(gauge -> resultsGarbageCollector.put(gauge.getId().getName(), gauge.value()));
+
+        Collection<Counter> counters = Search.in(this.meterRegistry).name(s -> s.contains("jvm.gc") && !s.contains("jvm.gc.pause")).counters();
+        counters.forEach(counter -> resultsGarbageCollector.put(counter.getId().getName(), counter.count()));
+
+        gauges = Search.in(this.meterRegistry).name(s -> s.contains("jvm.classes.loaded")).gauges();
+        Double classesLoaded = gauges.stream().map(Gauge::value).reduce((x, y) -> (x + y)).orElse((double) 0);
+        resultsGarbageCollector.put("classesLoaded", classesLoaded);
+
+        Collection<FunctionCounter> functionCounters = Search.in(this.meterRegistry).name(s -> s.contains("jvm.classes.unloaded")).functionCounters();
+        Double classesUnloaded = functionCounters.stream().map(FunctionCounter::count).reduce((x, y) -> (x + y)).orElse((double) 0);
+        resultsGarbageCollector.put("classesUnloaded", classesUnloaded);
+
+        return resultsGarbageCollector;
+    }
+
+    private Map<String, Map<String, Number>> databaseMetrics() {
+        Map<String, Map<String, Number>> resultsDatabase = new HashMap<>();
+
+        Collection<Timer> timers = Search.in(this.meterRegistry).name(s -> s.contains("hikari")).timers();
+        timers.forEach(timer -> {
+            String key = timer.getId().getName().substring(timer.getId().getName().lastIndexOf('.') + 1);
+
+            resultsDatabase.putIfAbsent(key, new HashMap<>());
+            resultsDatabase.get(key).put("count", timer.count());
+            resultsDatabase.get(key).put("max", timer.max(TimeUnit.MILLISECONDS));
+            resultsDatabase.get(key).put("totalTime", timer.totalTime(TimeUnit.MILLISECONDS));
+            resultsDatabase.get(key).put("mean", timer.mean(TimeUnit.MILLISECONDS));
+
+            ValueAtPercentile[] percentiles = timer.takeSnapshot().percentileValues();
+            for (ValueAtPercentile percentile : percentiles) {
+                resultsDatabase.get(key).put(String.valueOf(percentile.percentile()), percentile.value(TimeUnit.MILLISECONDS));
+            }
+        });
+
+        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("hikari")).gauges();
+        gauges.forEach(gauge -> {
+            String key = gauge.getId().getName().substring(gauge.getId().getName().lastIndexOf('.') + 1);
+            resultsDatabase.putIfAbsent(key, new HashMap<>());
+            resultsDatabase.get(key).put("value", gauge.value());
+        });
+
+        return resultsDatabase;
+    }
+
+    private Map<String, Map> serviceMetrics() {
+        Collection<String> crudOperation = Arrays.asList("GET", "POST", "PUT", "DELETE");
+
+        Set<String> uris = new HashSet<>();
+        Collection<Timer> timers = this.meterRegistry.find("http.server.requests").timers();
+
+        timers.forEach(timer -> uris.add(timer.getId().getTag("uri")));
+        Map<String, Map> resultsHttpPerUri = new HashMap<>();
+
+        uris.forEach(uri -> {
+            Map<String, Map> resultsPerUri = new HashMap<>();
+
+            crudOperation.forEach(operation -> {
+                Map<String, Number> resultsPerUriPerCrudOperation = new HashMap<>();
+
+                Collection<Timer> httpTimersStream = this.meterRegistry.find("http.server.requests").tags("uri", uri, "method", operation).timers();
+                long count = httpTimersStream.stream().map(Timer::count).reduce((x, y) -> x + y).orElse(0L);
+
+                if (count != 0) {
+                    double max = httpTimersStream.stream().map(x -> x.max(TimeUnit.MILLISECONDS)).reduce((x, y) -> x > y ? x : y).orElse((double) 0);
+                    double totalTime = httpTimersStream.stream().map(x -> x.totalTime(TimeUnit.MILLISECONDS)).reduce((x, y) -> (x + y)).orElse((double) 0);
+
+                    resultsPerUriPerCrudOperation.put("count", count);
+                    resultsPerUriPerCrudOperation.put("max", max);
+                    resultsPerUriPerCrudOperation.put("mean", totalTime / count);
+
+                    resultsPerUri.put(operation, resultsPerUriPerCrudOperation);
+                }
+            });
+
+            resultsHttpPerUri.put(uri, resultsPerUri);
+        });
+
+        return resultsHttpPerUri;
+    }
+
+    private Map<String, Map<String, Number>> cacheMetrics() {
+        Map<String, Map<String, Number>> resultsCache = new HashMap<>();
+
+        Collection<FunctionCounter> counters = Search.in(this.meterRegistry).name(s -> s.contains("cache") && !s.contains("hibernate")).functionCounters();
+        counters.forEach(counter -> {
+            String key = counter.getId().getName();
+            String name = counter.getId().getTag("name");
+            if (name != null) {
+                resultsCache.putIfAbsent(name, new HashMap<>());
+                if (counter.getId().getTag("result") != null) {
+                    key += "." + counter.getId().getTag("result");
+                }
+                resultsCache.get(name).put(key, counter.count());
+            } else {
+                logger.warn(MISSING_NAME_TAG_MESSAGE, key);
+            }
+        });
+
+        Collection<Gauge> gauges = Search.in(this.meterRegistry).name(s -> s.contains("cache")).gauges();
+        gauges.forEach(gauge -> {
+            String key = gauge.getId().getName();
+            String name = gauge.getId().getTag("name");
+            if (name != null) {
+                resultsCache.putIfAbsent(name, new HashMap<>());
+                resultsCache.get(name).put(key, gauge.value());
+            } else {
+                logger.warn(MISSING_NAME_TAG_MESSAGE, key);
+            }
+        });
+        return resultsCache;
+    }
+
+    private Map<String, Map<String, Number>> jvmMemoryMetrics() {
+        Map<String, Map<String, Number>> resultsJvm = new HashMap<>();
+
+        Search jvmUsedSearch = Search.in(this.meterRegistry).name(s -> s.contains("jvm.memory.used"));
+
+        Collection<Gauge> gauges = jvmUsedSearch.gauges();
+        gauges.forEach(gauge -> {
+            String key = gauge.getId().getTag("id");
+            resultsJvm.putIfAbsent(key, new HashMap<>());
+            resultsJvm.get(key).put("used", gauge.value());
+        });
+
+        Search jvmMaxSearch = Search.in(this.meterRegistry).name(s -> s.contains("jvm.memory.max"));
+
+        gauges = jvmMaxSearch.gauges();
+        gauges.forEach(gauge -> {
+            String key = gauge.getId().getTag("id");
+            resultsJvm.get(key).put("max", gauge.value());
+        });
+
+        gauges = Search.in(this.meterRegistry).name(s -> s.contains("jvm.memory.committed")).gauges();
+        gauges.forEach(gauge -> {
+            String key = gauge.getId().getTag("id");
+            resultsJvm.get(key).put("committed", gauge.value());
+        });
+
+        return resultsJvm;
+    }
+
+    private Map<String, Map> httpRequestsMetrics() {
+        Set<String> statusCode = new HashSet<>();
+        Collection<Timer> timers = this.meterRegistry.find("http.server.requests").timers();
+
+        timers.forEach(timer -> statusCode.add(timer.getId().getTag("status")));
+
+        Map<String, Map> resultsHttp = new HashMap<>();
+        Map<String, Map<String, Number>> resultsHttpPerCode = new HashMap<>();
+
+        statusCode.forEach(code -> {
+            Map<String, Number> resultsPerCode = new HashMap<>();
+
+            Collection<Timer> httpTimersStream = this.meterRegistry.find("http.server.requests").tag("status", code).timers();
+            long count = httpTimersStream.stream().map(Timer::count).reduce((x, y) -> x + y).orElse(0L);
+            double max = httpTimersStream.stream().map(x -> x.max(TimeUnit.MILLISECONDS)).reduce((x, y) -> x > y ? x : y).orElse((double) 0);
+            double totalTime = httpTimersStream.stream().map(x -> x.totalTime(TimeUnit.MILLISECONDS)).reduce((x, y) -> (x + y)).orElse((double) 0);
+
+            resultsPerCode.put("count", count);
+            resultsPerCode.put("max", max);
+            resultsPerCode.put("mean", count != 0 ? totalTime / count : 0);
+
+            resultsHttpPerCode.put(code, resultsPerCode);
+        });
+
+        resultsHttp.put("percode", resultsHttpPerCode);
+
+        timers = this.meterRegistry.find("http.server.requests").timers();
+        long countAllrequests = timers.stream().map(Timer::count).reduce((x, y) -> x + y).orElse(0L);
+        Map<String, Number> resultsHTTPAll = new HashMap<>();
+        resultsHTTPAll.put("count", countAllrequests);
+
+        resultsHttp.put("all", resultsHTTPAll);
+
+        return resultsHttp;
+    }
+
+}

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -26,6 +26,7 @@ const expectedFiles = {
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/JHipsterProperties.java`,
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/JsonbConfiguration.java`,
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/errors/BadRequestAlertException.java`,
+            `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/JHipsterMetricsEndpoint.java`,
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/util/HeaderUtil.java`,
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/util/ResponseUtil.java`,
             `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/ArchTest.java`,


### PR DESCRIPTION
linked to https://github.com/jhipster/generator-jhipster-quarkus/issues/145

The jhimetrics are from the JHipster lib We can't include this lib because of Spring relative feature. I've created our own /jhimetrics endpoint.

but we can't the following metrics:
* Thread Dump (from Spring boot actuator)
* Database
* Cache

I removed the related code.

