### PR TITLE
Change prometheus url to match with the JHipster one

### DIFF
--- a/generators/server/templates/quarkus/src/main/resources/application.properties.ejs
+++ b/generators/server/templates/quarkus/src/main/resources/application.properties.ejs
@@ -32,7 +32,8 @@ quarkus.mailer.ssl=false
 quarkus.mailer.username=
 quarkus.mailer.password=
 
-quarkus.micrometer.export.prometheus.path=/management/jhimetrics
+quarkus.micrometer.export.prometheus.enabled=true
+quarkus.micrometer.export.prometheus.path=/management/prometheus
 
 quarkus.smallrye-health.root-path=/management/health
 


### PR DESCRIPTION
Quick fix to change the metrics URL.

`/management/prometheus` should be used to export metrics to prometheus
`/management/jhimetrics` is a specific endpoint to display metric in the generated application and comes from JHipster-lib (in the main project)

@danielpetisme We need this for the 0.2.0 release 