### PR TITLE
Upgrade to Quarkus 1.11.0 

### DIFF
--- a/generators/generator-quarkus-constants.js
+++ b/generators/generator-quarkus-constants.js
@@ -1,5 +1,5 @@
 const DEFAULT_DATA_ACCESS = 'activeRecord';
-const QUARKUS_VERSION = '1.10.5.Final';
+const QUARKUS_VERSION = '1.11.0.Final';
 
 const CACHE_MAXIMUM_SIZE = 100;
 const CACHE_EXPIRE_AFTER_WRITE = '3600S';


### PR DESCRIPTION
To update as soon as 1.11.0 is release and do preventive tests before the final version is available.