### PR TITLE
Address the issue #179 - support for graddle build

### DIFF
--- a/generators/generator-quarkus-constants.js
+++ b/generators/generator-quarkus-constants.js
@@ -1,5 +1,5 @@
 const DEFAULT_DATA_ACCESS = 'activeRecord';
-const QUARKUS_VERSION = '1.12.2.Final';
+const QUARKUS_VERSION = '1.13.0.Final';
 
 const CACHE_MAXIMUM_SIZE = 100;
 const CACHE_EXPIRE_AFTER_WRITE = '3600S';

--- a/generators/server/templates/quarkus/build.gradle.ejs
+++ b/generators/server/templates/quarkus/build.gradle.ejs
@@ -241,6 +241,8 @@ dependencies {
     implementation "com.github.cloudyrock.mongock:mongodb-sync-v4-driver:${mongodb_driverSync_version}"
     implementation "org.mongodb:mongodb-driver-sync"
     implementation "org.apache.commons:commons-lang3"
+    implementation "org.apache.commons:commons-vfs2:${commons_vfs2_version}"
+    compileOnly "org.graalvm.nativeimage:svm:${graal_version}"
 <%_ } _%>
 <%_ if (!skipUserManagement) { _%>
     implementation "org.apache.commons:commons-lang3"

--- a/generators/server/templates/quarkus/gradle.properties.ejs
+++ b/generators/server/templates/quarkus/gradle.properties.ejs
@@ -18,7 +18,7 @@
 -%>
 rootProject.name=<%= dasherizedBaseName %>
 quarkusPluginVersion=<%= quarkusVersion %>
-quarkusPlatformArtifactId=quarkus-universe-bom
+quarkusPlatformArtifactId=quarkus-bom
 quarkusPlatformGroupId=io.quarkus
 quarkusPlatformVersion=<%= quarkusVersion %>
 
@@ -53,6 +53,8 @@ camel_quarkus_jackson_version=1.5.0
 <%_ if (databaseType === 'mongodb') { _%>
 mongockBom_version=4.1.19
 mongodb_driverSync_version=4.1.1
+commons_vfs2_version=2.0
+graal_version=21.0.0.2
 <%_ } _%>
 <%_ if (databaseType === 'sql' || authenticationType === 'uaa') { _%>
 jaxb_runtime_version=2.3.2

--- a/generators/server/templates/quarkus/gradle.properties.ejs
+++ b/generators/server/templates/quarkus/gradle.properties.ejs
@@ -18,7 +18,7 @@
 -%>
 rootProject.name=<%= dasherizedBaseName %>
 quarkusPluginVersion=<%= quarkusVersion %>
-quarkusPlatformArtifactId=quarkus-bom
+quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
 quarkusPlatformVersion=<%= quarkusVersion %>
 

--- a/generators/server/templates/quarkus/pom.xml.ejs
+++ b/generators/server/templates/quarkus/pom.xml.ejs
@@ -97,7 +97,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/generators/server/templates/quarkus/pom.xml.ejs
+++ b/generators/server/templates/quarkus/pom.xml.ejs
@@ -97,7 +97,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
+                <artifactId>quarkus-universe-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>


### PR DESCRIPTION
Beyond other things, it's needed to upgrade the Quarkus version for correct annotation processing.