### PR TITLE
Bump quarkus-resteasy-problem extension to v1.0.0

### DIFF
--- a/generators/server/templates/quarkus/pom.xml.ejs
+++ b/generators/server/templates/quarkus/pom.xml.ejs
@@ -43,7 +43,7 @@
         <!-- Dependency properties -->
         <quarkus.platform.version><%= quarkusVersion %></quarkus.platform.version>
         <mapstruct.version>1.3.1.Final</mapstruct.version>
-        <resteasy-problem.version>0.9.4</resteasy-problem.version>
+        <resteasy-problem.version>1.0.0</resteasy-problem.version>
         <archunit-junit5.version>0.12.0</archunit-junit5.version>
         <%_ if(authenticationType === 'oauth2') {_%>
         <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
No functional changes between `0.9.4` and `1.0.0` that would be relevant for `generator-jhipster-quarkus`

We've started preparation for Quarkus 2.0 in our extension project - `quarkus-restreasy-problem:1.X.Y` is supposed to work with Quarkus 1.X, and - once Quarkus 2.0 is available - we will also bump our extension version to 2.0