### PR TITLE
Bump quarkus-resteasy-problem extension to v2.0.0

### DIFF
--- a/generators/server/templates/quarkus/pom.xml.ejs
+++ b/generators/server/templates/quarkus/pom.xml.ejs
@@ -43,7 +43,7 @@
         <!-- Dependency properties -->
         <quarkus.platform.version><%= quarkusVersion %></quarkus.platform.version>
         <mapstruct.version>1.3.1.Final</mapstruct.version>
-        <resteasy-problem.version>1.0.0</resteasy-problem.version>
+        <resteasy-problem.version>2.0.0</resteasy-problem.version>
         <archunit-junit5.version>0.12.0</archunit-junit5.version>
         <%_ if(authenticationType === 'oauth2') {_%>
         <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
quarkus-resteasy-problem:2.0.0 is functionally equal to v1.0.0, but is compiled against Quarkus 2.0 dependencies, so will be more stable in the long run with Quarkus 2.0