### PR TITLE
Fix swagger annotation import

### DIFF
--- a/generators/quarkus/templates/pom.xml.ejs
+++ b/generators/quarkus/templates/pom.xml.ejs
@@ -52,6 +52,7 @@
         <resteasy-problem.version>3.9.0</resteasy-problem.version>
         <archunit-junit5.version>1.3.0</archunit-junit5.version>
         <assertj.version>3.26.0</assertj.version>
+        <swagger.version>1.6.14</swagger.version>
         <%_ if(authenticationType === 'oauth2') {_%>
         <wiremock.version>3.0.1</wiremock.version>
         <%_ } _%>
@@ -206,6 +207,11 @@ _%>
             <groupId>com.tietoevry.quarkus</groupId>
             <artifactId>quarkus-resteasy-problem</artifactId>
             <version>${resteasy-problem.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/domain/_persistClass_.java.ejs
@@ -69,7 +69,7 @@ import org.springframework.data.cassandra.core.mapping.Column;
 import org.springframework.data.cassandra.core.mapping.Table;
 <%_ } if (importJsonIgnore === true) { _%>
 import com.fasterxml.jackson.annotation.JsonIgnore;
-<%_ } if (!dtoMapstruct && typeof javadoc != 'undefined') { _%>
+<%_ } if (!dtoMapstruct && entityApiDescription) { _%>
 import io.swagger.annotations.ApiModel;
 <%_ } if (!dtoMapstruct && importApiModelProperty === true) { _%>
 import io.swagger.annotations.ApiModelProperty;


### PR DESCRIPTION
The test to include `import io.swagger.annotations.ApiModel` in an entity was failing to include the import. 

Also the swagger annotations package was missing from `pom.xml`.