### PR TITLE
Renaming the wrongly left @RequestParam to @QueryParam

### DIFF
--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/common/get_all.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/common/get_all.ejs
@@ -20,7 +20,7 @@
     @Transactional
     <%_ } _%>
     <%_ if (paginationAny) { _%>
-    public Response getAll<%= entityClassPlural %>(@BeanParam PageRequestVM pageRequest, @BeanParam SortRequestVM sortRequest, @Context UriInfo uriInfo<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @QueryParam(value = "eagerload") boolean eagerload<% } %>) {
+    public Response getAll<%= entityClassPlural %>(@BeanParam PageRequestVM pageRequest, @BeanParam SortRequestVM sortRequest, @Context UriInfo uriInfo<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @QueryParam(value = "eagerload") boolean eagerload<% } %>) {
         log.debug("REST request to get a page of <%= entityClassPlural %>");
         var page = pageRequest.toPage();
         var sort = sortRequest.toSort();
@@ -58,7 +58,7 @@
         return response.build();
     }
     <%_ } else { _%>
-    public List<<%= restClass %>> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@QueryParam(value = "eagerload") boolean eagerload<% }%>) {
+    public List<<%= restClass %>> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@QueryParam(value = "eagerload") boolean eagerload<% }%>) {
         log.debug("REST request to get all <%= entityClassPlural %>");
         <%_ if (viaService) { _%>
         return <%= entityInstance %>Service.findAll();

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/common/search.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/common/search.ejs
@@ -18,10 +18,10 @@
 -%>
 <%_
     if (pagination === 'no') { %>
-    public List<<%= restClass %>> search<%= entityClassPlural %>(@RequestParam String query) {
+    public List<<%= restClass %>> search<%= entityClassPlural %>(@QueryParam(value = "query") String query) {
         log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService}); -%>
     <% } if (pagination !== 'no') { %>
-    public ResponseEntity<List<<%= restClass %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %>) {
+    public ResponseEntity<List<<%= restClass %>>> search<%= entityClassPlural %>(@QueryParam(value = "query") String query, Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %>) {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= restClass %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
         Page<<%= persistClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/web/get_all.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/imperative/web/get_all.ejs
@@ -31,7 +31,7 @@
     @Transactional
     <%_ } _%>
     <%_ if (paginationAny) { _%>
-    public Response getAll<%= entityClassPlural %>(@BeanParam PageRequestVM pageRequest, @BeanParam SortRequestVM sortRequest, @Context UriInfo uriInfo<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @QueryParam(value = "eagerload") boolean eagerload<% } %>) {
+    public Response getAll<%= entityClassPlural %>(@BeanParam PageRequestVM pageRequest, @BeanParam SortRequestVM sortRequest, @Context UriInfo uriInfo<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @QueryParam(value = "eagerload") boolean eagerload<% } %>) {
         log.debug("REST request to get a page of <%= entityClassPlural %>");
         var page = pageRequest.toPage();
         var sort = sortRequest.toSort();
@@ -69,7 +69,7 @@
         return response.build();
     }
     <%_ } else { _%>
-    public List<<%= restClass %>> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@QueryParam(value = "eagerload") boolean eagerload<% }%>) {
+    public List<<%= restClass %>> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@QueryParam(value = "eagerload") boolean eagerload<% }%>) {
         log.debug("REST request to get all <%= entityClassPlural %>");
         <%_ if (viaService) { _%>
         return <%= entityInstance %>Service.findAll();


### PR DESCRIPTION
I saw that some @RequestParams from spring resources are left , they should be migrated to QueryParams otherwise you will get compile time errors since this annotations don't exist in jax rs. 

P.S. the param itself is not used in one case but still might be used in the future I guess this is why it has been left.