### PR TITLE
test: execute liquibase with 'test' context during integration tests

### DIFF
--- a/.github/workflows/smoke-test-imperative.yml
+++ b/.github/workflows/smoke-test-imperative.yml
@@ -152,7 +152,10 @@ jobs:
               run: npm run ci:e2e:package
             - name: 'E2E: Start docker-compose containers for e2e tests'
               if: steps.compare.outputs.equals != 'true'
-              run: npm run ci:e2e:prepare
+              run: |
+                  # Required until https://github.com/jhipster/generator-jhipster/pull/30910 is released
+                  sed -i 's/docker.io\/bitnami\/consul/hashicorp\/consul/g' src/main/docker/consul.yml || true
+                  npm run ci:e2e:prepare
             - name: 'E2E: Run'
               if: steps.compare.outputs.equals != 'true'
               id: e2e

--- a/generators/quarkus/templates/partials/data_application.properties.ejs
+++ b/generators/quarkus/templates/partials/data_application.properties.ejs
@@ -99,6 +99,7 @@ quarkus.mongodb.database=<%= baseName %>
 <%_ if (databaseType === 'sql') { _%>
 quarkus.liquibase.change-log=config/liquibase/master.xml
 quarkus.liquibase.migrate-at-start=true
+%test.quarkus.liquibase.contexts=test
 <%_ if (prodDatabaseType !== devDatabaseType) { _%>
 %test.quarkus.datasource.jdbc.url=jdbc:h2:mem:test;MODE=LEGACY
 %test.quarkus.datasource.db-kind=h2


### PR DESCRIPTION
Thus faker data are not loaded when executing tests, and doesn't interfere with the data setup by the tests. 
Fixes #220