### PR TITLE
Fix #3: Quarkus reactive programming support

### DIFF
--- a/generators/bootstrap-application/generator.js
+++ b/generators/bootstrap-application/generator.js
@@ -9,6 +9,9 @@ export default class extends BaseApplicationGenerator {
     get [BaseApplicationGenerator.CONFIGURING]() {
         return this.asConfiguringTaskGroup({
             async configuringTemplateTask() {
+                if (this.jhipsterConfig.reactive === undefined) {
+                    this.jhipsterConfig.reactive = false;
+                }
                 if (!this.jhipsterConfig.cacheProvider) {
                     this.jhipsterConfig.cacheProvider = 'no';
                 }

--- a/generators/quarkus/command.js
+++ b/generators/quarkus/command.js
@@ -4,7 +4,7 @@ import { command as serverCommand } from 'generator-jhipster/generators/server';
 import { command as springBootCommand } from 'generator-jhipster/generators/spring-boot';
 
 const { applicationType } = serverCommand.configs;
-const { defaultPackaging } = springBootCommand.configs;
+const { defaultPackaging, reactive: reactiveConfig } = springBootCommand.configs;
 
 import { asCommand } from 'generator-jhipster';
 
@@ -69,6 +69,13 @@ export default asCommand({
                 { value: 'gradle', name: 'Gradle' },
             ],
             scope: 'storage',
+        },
+        reactive: {
+            ...reactiveConfig,
+            prompt: gen => ({
+                ...reactiveConfig.prompt(gen),
+                message: 'Do you want to use Quarkus reactive programming model?',
+            }),
         },
         databaseType: {
             prompt: {

--- a/generators/quarkus/generator.js
+++ b/generators/quarkus/generator.js
@@ -100,6 +100,8 @@ export default class extends BaseApplicationGenerator {
         return this.asPreparingTaskGroup({
             async prepareQuarkusRendering({ entity }) {
                 entity.dataAccess = entity.dataAccess ?? DEFAULT_DATA_ACCESS;
+                entity.reactive = entity.reactive ?? this.jhipsterConfigWithDefaults.reactive;
+                entity.imperativeOrReactive = entity.reactive ? 'reactive' : 'imperative';
                 entity.viaService = entity.service !== 'no';
                 entity.hasServiceImpl = entity.service === 'serviceImpl';
                 entity.viaRepository = entity.dataAccess === 'repository';

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/create.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/create.ejs
@@ -1,0 +1,47 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+    /**
+     * {@code POST  /<%= entityApiUrl %>} : Create a new <%= entityInstance %>.
+     *
+     * @param <%= restInstance %> the <%= restInstance %> to create.
+     * @return the {@link Response} with status {@code 201 (Created)} and with body the new <%= restInstance %>, or with status {@code 400 (Bad Request)} if the <%= entityInstance %> has already an ID.
+     */
+    @POST
+    <%_ if (databaseType === 'sql' && !viaService) { _%>
+    @Transactional
+    <%_ } _%>
+    public Uni<Response> create<%= entityClass %>(<% if (anyPropertyHasValidation) { %>@Valid <% } %><%= restClass %> <%= restInstance %>, @Context UriInfo uriInfo) {
+        log.debug("REST request to save <%= entityClass %> : {}", <%= restInstance %>);
+        if (<%= restInstance %>.id != null) {
+            throw new BadRequestAlertException("A new <%= entityInstance %> cannot already have an ID", ENTITY_NAME, "idexists");
+        }
+        <%_ if (databaseType === 'cassandra') { _%>
+        <%= restInstance %>.id = UUID.randomUUID();
+        <%_ } _%>
+        <%_ if (databaseType === 'mongodb') { _%>
+            <%= restInstance %>.id = idGenerator.generate();
+        <%_ } _%>
+<%- include('../../imperative/common/save', {...this, returnDirectly: false, isController: true}); -%>
+        <%_ if (databaseType === 'mongodb' && !viaService) { _%>
+        <%= entityClass %> result = <%= entityClass %>.findById(<%= restInstance %>.id);
+        <%_ } _%>
+        var response = Response.created(fromPath(uriInfo.getPath()).path(result.id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>).build()).entity(result);
+        HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>).forEach(response::header);
+        return Uni.createFrom().item(response.build());
+    }

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/delete.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/delete.ejs
@@ -1,0 +1,36 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+    /**
+     * {@code DELETE  /<%= entityApiUrl %>/:id} : delete the "id" <%= entityInstance %>.
+     *
+     * @param id the id of the <%= restInstance %> to delete.
+     * @return the {@link Response} with status {@code 204 (NO_CONTENT)}.
+     */
+    @DELETE
+    @Path("/{id}")
+    <%_ if (databaseType === 'sql' && !viaService) { _%>
+    @Transactional
+    <%_ } _%>
+    public Uni<Response> delete<%= entityClass %>(@PathParam("id") <%= primaryKeyType %> id) {
+        log.debug("REST request to delete <%= entityClass %> : {}", id);
+<%- include('../../imperative/common/delete', this); -%>
+        var response = Response.noContent();
+        HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>).forEach(response::header);
+        return Uni.createFrom().item(response.build());
+    }

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/get.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/get.ejs
@@ -1,0 +1,34 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+    /**
+     * {@code GET  /<%= entityApiUrl %>/:id} : get the "id" <%= entityInstance %>.
+     *
+     * @param id the id of the <%= restInstance %> to retrieve.
+     * @return the {@link Response} with status {@code 200 (OK)} and with body the <%= restInstance %>, or with status {@code 404 (Not Found)}.
+     */
+    @GET
+    @Path("/{id}")
+    <%_ if (databaseType === 'sql' && isUsingMapsId === true && !viaService) { _%>
+    @Transactional(readOnly = true)
+    <%_ } %>
+    public Uni<Response> get<%= entityClass %>(@PathParam("id") <%= primaryKeyType %> id) {
+        log.debug("REST request to get <%= entityClass %> : {}", id);
+<%- include('../../imperative/common/get', {...this, returnDirectly: false}); -%>
+        return Uni.createFrom().item(ResponseUtil.wrapOrNotFound(<%= restInstance %>));
+    }

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/get_all.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/get_all.ejs
@@ -1,0 +1,85 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+    /**
+     * {@code GET  /<%= entityApiUrl %>} : get all the <%= entityInstancePlural %>.
+     *<%_ if (paginationAny) { %>
+     * @param pageRequest the pagination information.
+    <%_ } _%>
+    <%_ if (fieldsContainOwnerManyToMany) { _%>
+     * @param eagerload flag to eager load entities from relationships (This is applicable for many-to-many).
+    <%_ } _%>
+     * @return the {@link Response} with status {@code 200 (OK)} and the list of <%= entityInstancePlural %> in body.
+     */
+    @GET
+    <%_ if (databaseType === 'sql' && fieldsContainOwnerManyToMany && !viaService) { _%>
+    @Transactional
+    <%_ } _%>
+    <%_ if (paginationAny) { _%>
+    public Uni<Response> getAll<%= entityClassPlural %>(@BeanParam PageRequestVM pageRequest, @BeanParam SortRequestVM sortRequest, @Context UriInfo uriInfo<% if (fieldsContainNoOwnerOneToOne) { %>, @QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @QueryParam(value = "eagerload") boolean eagerload<% } %>) {
+        log.debug("REST request to get a page of <%= entityClassPlural %>");
+        var page = pageRequest.toPage();
+        var sort = sortRequest.toSort();
+            <%_ if (viaService) { _%>
+                <%_ if (fieldsContainOwnerManyToMany) { _%>
+        Paged<<%= restClass %>> result;
+        if (eagerload) {
+            result = <%= entityInstance %>Service.findAllWithEagerRelationships(page);
+        } else {
+            result = <%= entityInstance %>Service.findAll(page);
+        }
+                <%_ } else { _%>
+        Paged<<%= restClass %>> result = <%= entityInstance %>Service.findAll(page);
+                <%_ } _%>
+        <%_ } else { _%>
+            <%_ if (fieldsContainOwnerManyToMany) { _%>
+        Paged<<%= restClass %>> result;
+        if (eagerload) {
+            var <%= entityInstancePlural %> = <%= dataAccessObject %>.findAllWithEagerRelationships().page(page).list();
+            var totalCount = <%= dataAccessObject %>.findAll().count();
+            var pageCount = <%= dataAccessObject %>.findAll().page(page).pageCount();
+            result = new Paged<>(page.index, page.size, totalCount, pageCount, <%= entityInstancePlural %>);
+        } else {
+            result = new Paged<>(<%= dataAccessObject %>.findAll(sort).page(page));
+        }
+            <%_ } else { _%>
+        var result = new Paged<>(<%= dataAccessObject %>.findAll(sort).page(page));
+            <%_ } _%>
+        <%_ if (dtoMapstruct) { _%>
+        result = result.map(<%= entityInstance %> -> <%= mapper %>.toDto(<%= entityInstance %>));
+        <%_ } _%>
+        <%_ } _%>
+        var response = Response.ok().entity(result.content);
+        response = PaginationUtil.withPaginationInfo(response, uriInfo, result);
+        return Uni.createFrom().item(response.build());
+    }
+    <%_ } else { _%>
+    public Uni<Response> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@QueryParam(value = "filter") String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@QueryParam(value = "eagerload") boolean eagerload<% }%>) {
+        log.debug("REST request to get all <%= entityClassPlural %>");
+        List<<%= restClass %>> result;
+        <%_ if (viaService) { _%>
+        result = <%= entityInstance %>Service.findAll();
+        <%_ } else if (dtoMapstruct) { _%>
+        List<<%= entityClass %>> <%= entityInstancePlural %> = <%= dataAccessObject %>.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships()<% } else { %>findAll()<% } %>.list();
+        result = <%= mapper %>.toDto(<%= entityInstancePlural %>);
+        <%_ } else { _%>
+        result = <%= dataAccessObject %>.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships()<% } else { %>findAll()<% } %>.list();
+        <%_ } _%>
+        return Uni.createFrom().item(Response.ok().entity(result).build());
+    }
+    <%_ } _%>

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/imports.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/imports.ejs
@@ -1,0 +1,98 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import static jakarta.ws.rs.core.UriBuilder.fromPath;
+
+<%_ if (!(dtoMapstruct && viaService)) { _%>
+import <%=packageName%>.domain.<%= entityClass %>;
+<%_ } _%>
+<%_ if (viaService) { _%>
+import <%=packageName%>.service.<%= entityClass %>Service;
+<%_ } _%>
+<%_ if (viaRepository) { _%>
+import <%=packageName%>.repository.<%= entityClass %>Repository;
+    <%_ if (isUsingMapsId === true) { _%>
+import <%=packageName%>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
+    <%_ } _%>
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;
+    <%_ } _%>
+<%_ } _%>
+<%_ if (saveUserSnapshot) { _%>
+import <%=packageName%>.domain.User;
+<%_ } _%>
+<%_ if (databaseType === 'mongodb') { _%>
+import <%=packageName%>.service.IdGenerator;
+<%_ } _%>
+import <%=packageName%>.web.rest.errors.BadRequestAlertException;
+import <%=packageName%>.web.util.HeaderUtil;
+import <%=packageName%>.web.util.ResponseUtil;
+<%_ if (dtoMapstruct) { _%>
+import <%=packageName%>.service.dto.<%= restClass %>;
+    <%_ if (!viaService) { _%>
+import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;
+    <%_ } _%>
+<%_ } _%>
+<%_ if (jpaMetamodelFiltering) {  _%>
+import <%=packageName%>.service.dto.<%= entityClass %>Criteria;
+import <%=packageName%>.service.<%= entityClass %>QueryService;
+<%_ } _%>
+
+import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+<%_ if (paginationAny) { _%>
+import <%= packageName %>.service.Paged;
+import <%= packageName %>.web.rest.vm.PageRequestVM;
+import <%= packageName %>.web.rest.vm.SortRequestVM;
+import <%= packageName %>.web.util.PaginationUtil;
+<%_ } _%>
+
+import jakarta.enterprise.context.ApplicationScoped;
+<%_ if (viaService || viaRepository || dtoMapstruct || databaseType === 'mongodb') { _%>
+import jakarta.inject.Inject;
+<%_ } _%>
+<%_ if (databaseType === 'sql' && !viaService) { %>
+import jakarta.transaction.Transactional;
+<%_ } _%>
+<%_ if (anyPropertyHasValidation) { _%>
+import jakarta.validation.Valid;
+<%_ } _%>
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+<%_ if (!paginationAny && dtoMapstruct && !viaService && fieldsContainNoOwnerOneToOne === true) { _%>
+import java.util.LinkedList;
+<%_ } _%>
+import java.util.List;
+<%_ if (isUsingMapsId === true) { _%>
+import java.util.Objects;
+<%_ } _%>
+import java.util.Optional;
+<%_ if (databaseType === 'cassandra') { _%>
+import java.util.UUID;
+<%_ } _%>
+<%_ if (!viaService && (searchEngine === 'elasticsearch' || fieldsContainNoOwnerOneToOne === true)) { _%>
+import java.util.stream.Collectors;
+<%_ } _%>
+<%_ if (searchEngine === 'elasticsearch' || fieldsContainNoOwnerOneToOne === true) { _%>
+import java.util.stream.StreamSupport;
+<%_ } _%>
+<%_ if (searchEngine === 'elasticsearch') { _%>
+import static org.elasticsearch.index.query.QueryBuilders.*;
+<%_ } _%>

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/update.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/_partials/reactive/web/update.ejs
@@ -1,0 +1,41 @@
+<%#
+ Copyright 2020-2026 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+    /**
+     * {@code PUT  /<%= entityApiUrl %>} : Updates an existing <%= entityInstance %>.
+     *
+     * @param <%= restInstance %> the <%= restInstance %> to update.
+     * @return the {@link Response} with status {@code 200 (OK)} and with body the updated <%= restInstance %>,
+     * or with status {@code 400 (Bad Request)} if the <%= restInstance %> is not valid,
+     * or with status {@code 500 (Internal Server Error)} if the <%= restInstance %> couldn't be updated.
+     */
+    @PUT
+    @Path("/{id}")
+    <%_ if (databaseType === 'sql' && !viaService) { _%>
+    @Transactional
+    <%_ } _%>
+    public Uni<Response> update<%= entityClass %>(<% if (anyPropertyHasValidation) { %>@Valid <% } %><%= restClass %> <%= restInstance %>, @PathParam("id") <%= primaryKeyType %> id) {
+        log.debug("REST request to update <%= entityClass %> : {}", <%= restInstance %>);
+        if (<%= restInstance %>.id == null) {
+            throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
+        }
+<%- include('../../imperative/common/save', {...this, returnDirectly: false}); -%>
+        var response = Response.ok().entity(<% if (databaseType === 'sql') { %>result<% } else { %><%= restInstance %><% } %>);
+        HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= restInstance %>.id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>).forEach(response::header);
+        return Uni.createFrom().item(response.build());
+    }

--- a/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs
+++ b/generators/quarkus/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs
@@ -18,7 +18,7 @@
 -%>
 package <%=packageName%>.web.rest;
 
-<%- include('../../_partials/imperative/web/imports', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/imports`, this); -%>
 
 /**
  * REST controller for managing {@link <%= packageName %>.domain.<%= persistClass %>}.
@@ -43,23 +43,23 @@ public class <%= entityClass %>Resource {
 
 <%_ } _%>
 <%_ } _%>
-<%- include('../../_partials/imperative/common/inject', { ...this, constructorName: entityClass + 'Resource', queryService: jpaMetamodelFiltering, isController: true}); -%>
+<%- include('../../_partials/imperative/common/inject', { ...this, reactive: false, constructorName: entityClass + 'Resource', queryService: jpaMetamodelFiltering, isController: true}); -%>
 <%_ if (!readOnly) { _%>
-<%- include('../../_partials/imperative/web/create', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/create`, this); -%>
 
-<%- include('../../_partials/imperative/web/update', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/update`, this); -%>
 
-<%- include('../../_partials/imperative/web/delete', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/delete`, this); -%>
 
 <%_ } _%>
 <%_ if (jpaMetamodelFiltering) {  %>
 <%- include('../../_partials/imperative/web/get_all_filtered', this); -%>
 <%_ } else { _%>
-<%- include('../../_partials/imperative/web/get_all', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/get_all`, this); -%>
 <%_ } _%>
 
 
-<%- include('../../_partials/imperative/web/get', this); -%>
+<%- include(`../../_partials/${imperativeOrReactive}/web/get`, this); -%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
 
 <%- include('../../_partials/imperative/web/search', this); -%>


### PR DESCRIPTION
## Summary

This PR resolves #3.

### Changes

Finished Quarkus reactive model support by wiring reactive config/prompt, propagating reactive mode into entity rendering, and fixing resource template routing to reactive partials while preserving imperative fallbacks for unsupported filtered/search endpoints.

### Files Modified

- `generators/bootstrap-application/generator.js`
- `generators/quarkus/command.js`
- `generators/quarkus/generator.js`
- `generators/quarkus/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs`

Happy to address any feedback or make adjustments.

/claim #3