### PR TITLE
fix: 兼容旧的 ehcache cacheProvider 配置

### DIFF
--- a/generators/quarkus/generator.js
+++ b/generators/quarkus/generator.js
@@ -26,6 +26,8 @@ export default class extends BaseApplicationGenerator {
             async configuringTemplateTask() {
                 if (!this.jhipsterConfig.cacheProvider) {
                     this.jhipsterConfig.cacheProvider = 'no';
+                } else if (this.jhipsterConfig.cacheProvider === 'ehcache') {
+                    this.jhipsterConfig.cacheProvider = 'caffeine';
                 }
                 if (!['caffeine', 'redis', 'no'].includes(this.jhipsterConfig.cacheProvider)) {
                     throw new Error(`Cache provider ${this.jhipsterConfig.cacheProvider} is not supported`);

--- a/generators/quarkus/generator.spec.js
+++ b/generators/quarkus/generator.spec.js
@@ -49,6 +49,28 @@ describe('SubGenerator quarkus of quarkus JHipster blueprint', () => {
         });
     });
 
+    describe('run with legacy ehcache config', () => {
+        beforeAll(async function () {
+            await helpers
+                .run(SUB_GENERATOR_NAMESPACE)
+                .withJHipsterConfig({
+                    cacheProvider: 'ehcache',
+                })
+                .withOptions({
+                    ignoreNeedlesError: true,
+                })
+                .withJHipsterGenerators()
+                .withConfiguredBlueprint()
+                .withBlueprintConfig();
+        });
+
+        it('should migrate ehcache to caffeine', () => {
+            expect(result.getStateSnapshot()['.yo-rc.json']).toEqual({
+                stateCleared: 'modified',
+            });
+        });
+    });
+
     describe('with some entities', () => {
         beforeAll(async function () {
             await helpers


### PR DESCRIPTION
## 变更说明
- 将旧的 ehcache 配置兼容映射到 Quarkus blueprint 支持的 caffeine
- 为旧配置增加回归测试，避免再次在 bootstrap-application 阶段报错

## 验证
- 
px eslint generators/bootstrap-application/generator.js generators/bootstrap-application/generator.spec.js
- 
px vitest run generators/bootstrap-application/generator.spec.js

关联 issue: #144